### PR TITLE
ParseJSONの整理

### DIFF
--- a/SimpleJsonParser/ParseJSON.cpp
+++ b/SimpleJsonParser/ParseJSON.cpp
@@ -221,9 +221,9 @@ std::any __stdcall ParseJSON( const std::string_view& jsonText, const concurrenc
 		default:
 			// 想定外は例外を飛ばす
 #if _HAS_CXX20
-			throw new std::runtime_error( std::format( "Unknown NotificationType: {}", static_cast<int>(type) ) );
+			throw std::runtime_error( std::format( "Unknown NotificationType: {}", static_cast<int>(type) ) );
 #else
-			throw new std::runtime_error( SPRINTF( "Unknown NotificationType: %d", static_cast<int>(type) ) );
+			throw std::runtime_error( SPRINTF( "Unknown NotificationType: %d", static_cast<int>(type) ) );
 #endif
 		}
 		return true; // trueを返すと、さらに子要素のパースを続ける	)
@@ -523,9 +523,9 @@ bool JsonParser::ParseElement()
 		}
 		// ここにきたらパースエラー
 #if _HAS_CXX20
-		throw new std::invalid_argument( std::format( "Parse error at m_offset {}: unexpected character '{}'", m_offset, GetChar() ) );
+		throw std::invalid_argument( std::format( "Parse error at m_offset {}: unexpected character '{}'", m_offset, GetChar() ) );
 #else
-		throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: unexpected character '%c'", m_offset, GetChar() ) );
+		throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: unexpected character '%c'", m_offset, GetChar() ) );
 #endif
 	}
 	// 末尾に来てる…ここにくるんだっけ？
@@ -553,9 +553,9 @@ bool JsonParser::ParseValues( NotificationType start, NotificationType end, bool
 		if( m_offset >= m_jsonText.length() )
 		{
 #if _HAS_CXX20
-			throw new std::invalid_argument( std::format( "Parse error at m_offset {}: unexpected end of data", m_offset ) );
+			throw std::invalid_argument( std::format( "Parse error at m_offset {}: unexpected end of data", m_offset ) );
 #else
-			throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: unexpected end of data", m_offset ) );
+			throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: unexpected end of data", m_offset ) );
 #endif
 		}
 		// 終端文字が来たのでブロック終了(必ずここに来る…はず)
@@ -567,9 +567,9 @@ bool JsonParser::ParseValues( NotificationType start, NotificationType end, bool
 		if( GetChar() != ',' )
 		{
 #if _HAS_CXX20
-			throw new std::invalid_argument( std::format( "Parse error at m_offset {}: expected ',' but found '{}'", m_offset, GetChar() ) );
+			throw std::invalid_argument( std::format( "Parse error at m_offset {}: expected ',' but found '{}'", m_offset, GetChar() ) );
 #else
-			throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected ',' but found '%c'", m_offset, GetChar() ) );
+			throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected ',' but found '%c'", m_offset, GetChar() ) );
 #endif
 		}
 	}
@@ -596,9 +596,9 @@ bool JsonParser::ParseKeyValue()
 	if( m_offset >= m_jsonText.length() || GetChar() != ':' )
 	{
 #if _HAS_CXX20
-		throw new std::invalid_argument( std::format( "Parse error at m_offset {}: expected ':' but found '{}'", m_offset, GetChar() ) );
+		throw std::invalid_argument( std::format( "Parse error at m_offset {}: expected ':' but found '{}'", m_offset, GetChar() ) );
 #else
-		throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected ':' but found '%c'", m_offset, GetChar() ) );
+		throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected ':' but found '%c'", m_offset, GetChar() ) );
 #endif
 	}
 	++m_offset;
@@ -658,9 +658,9 @@ bool JsonParser::ParseNumber()
 		if( m_offset >= m_jsonText.length() || !isdigit( GetChar() ) )	// 数字がないといけない
 		{
 #if _HAS_CXX20
-			throw new std::invalid_argument( std::format( "Parse error at m_offset {}: expected digit after 'e' or 'E' but found '{}'", m_offset, GetChar() ) );
+			throw std::invalid_argument( std::format( "Parse error at m_offset {}: expected digit after 'e' or 'E' but found '{}'", m_offset, GetChar() ) );
 #else
-			throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected digit after 'e' or 'E' but found '%c'", m_offset, GetChar() ) );
+			throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected digit after 'e' or 'E' but found '%c'", m_offset, GetChar() ) );
 #endif
 		}
 		while( isdigit( GetChar() ) )	// 数字が続く限り進める
@@ -703,9 +703,9 @@ std::string_view JsonParser::ParseStringValue()
 						{
 							// そもそも例外
 #if _HAS_CXX20
-							throw new std::invalid_argument( std::format( "Parse error at m_offset {}: expected hex digit after '\\u'", m_offset ) );
+							throw std::invalid_argument( std::format( "Parse error at m_offset {}: expected hex digit after '\\u'", m_offset ) );
 #else
-							throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected hex digit after '\\u'", m_offset ) );
+							throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: expected hex digit after '\\u'", m_offset ) );
 #endif
 						}
 					}
@@ -719,9 +719,9 @@ std::string_view JsonParser::ParseStringValue()
 			{
 				// エスケープ文字が定義されていない場合は例外
 #if _HAS_CXX20
-				throw new std::invalid_argument( std::format( "Parse error at m_offset {}: unexpected escape character '{}'", m_offset, currChar ) );
+				throw std::invalid_argument( std::format( "Parse error at m_offset {}: unexpected escape character '{}'", m_offset, currChar ) );
 #else
-				throw new std::invalid_argument( SPRINTF( "Parse error at m_offset %u: unexpected escape character '%c'", m_offset, currChar ) );
+				throw std::invalid_argument( SPRINTF( "Parse error at m_offset %u: unexpected escape character '%c'", m_offset, currChar ) );
 #endif
 			}
 		}

--- a/SimpleJsonParser/SimpleJsonParser.cpp
+++ b/SimpleJsonParser/SimpleJsonParser.cpp
@@ -157,7 +157,8 @@ int wmain( int argc, wchar_t* argv[] )
 		}
 		else
 		{
-			_ASSERTE( searchObj.has_value() && searchObj.type() == typeid(Morrin::JSON::JsonObject) );
+			_ASSERTE( searchObj.has_value() );
+			Trace( std::format( L"obj[{0}].type() == {1}", Morrin::JSON::ToWString( firstKeyName ), Morrin::JSON::ToWString( searchObj.type().name() ) ) );
 		}
 	}
 	return 0;


### PR DESCRIPTION
#### PR Classification
APIの変更。

#### PR Summary
`ParseJSON.cpp`内のデータ型を`std::string_view`から`JsonRefKeyType`に変更し、JSONパーサーのインターフェースを改善しました。
- `ParseJSON.cpp`: `LiteralValueDetail`および`EscapeCharDetail`構造体のメンバー型を変更。
- `ParseJSON.cpp`: `JsonParser`クラスのコンストラクタ引数とメンバー変数の型を変更。
- `ParseJSON.cpp`: `ParseStringValue`、`GetChar`、`IsWhiteSpace`メソッドの戻り値および引数の型を変更。
- `ParseJSON.cpp`: `ParseJSON`関数の引数とコールバックの型を変更。
- `SimpleJsonParser.cpp`: `searchObj`の型チェックを行わないようにアサーションを変更。
